### PR TITLE
Fix duckyPad keyboard not working while Autoswitcher is running (Linux)

### DIFF
--- a/src/duckypad_autoprofile.py
+++ b/src/duckypad_autoprofile.py
@@ -194,11 +194,21 @@ def duckypad_connect():
 
     if dpp_is_fw_compatible(user_selected_dp) is False:
         return False
+    
+    # Cache the HID path for open-close operations (helps with Linux keyboard issues)
+    from hid_common import set_cached_hid_path
+    set_cached_hid_path(user_selected_dp['hid_path'])
+    
     if open_hid_path(user_selected_dp, myh) is False:
         return False
     
     duckypad_sync_rtc(myh)
     time.sleep(0.1)
+    
+    # Close the persistent HID connection on Linux to avoid keyboard input issues
+    if 'linux' in sys.platform:
+        myh.close()
+    
     THIS_DUCKYPAD.device_type = user_selected_dp['dp_model']
     THIS_DUCKYPAD.info_dict = user_selected_dp
     connection_info_str.set(f"Connected!      Model: {dp_model_lookup.get(THIS_DUCKYPAD.device_type)}      Serial: {THIS_DUCKYPAD.info_dict.get('serial')}      Firmware: {THIS_DUCKYPAD.info_dict.get('fw_version')}")
@@ -235,9 +245,18 @@ HID_COMMAND_NEXT_PROFILE = 3
 HID_COMMAND_GOTO_PROFILE_BY_NAME = 23
 
 def duckypad_write_with_retry(data_buf):
+    from hid_common import hid_txrx_open_close
+    
+    # On Linux, use open-close mode to avoid keyboard issues
+    use_open_close = 'linux' in sys.platform
+    
     try:
-        dp_response = hid_txrx(data_buf, myh)
-        if len(dp_response) != PC_TO_DUCKYPAD_HID_BUF_SIZE:
+        if use_open_close:
+            dp_response = hid_txrx_open_close(data_buf)
+        else:
+            dp_response = hid_txrx(data_buf, myh)
+        # Linux hidapi may return fewer bytes than requested, just need enough to check status
+        if dp_response is None or len(dp_response) < 3:
             return DP_WRITE_FAIL
         if dp_response[2] == 0:
             return DP_WRITE_OK
@@ -252,8 +271,12 @@ def duckypad_write_with_retry(data_buf):
     try:
         print("SECOND TRY")
         duckypad_connect()
-        dp_response = hid_txrx(data_buf, myh)
-        if len(dp_response) != PC_TO_DUCKYPAD_HID_BUF_SIZE:
+        if use_open_close:
+            dp_response = hid_txrx_open_close(data_buf)
+        else:
+            dp_response = hid_txrx(data_buf, myh)
+        # Linux hidapi may return fewer bytes than requested, just need enough to check status
+        if dp_response is None or len(dp_response) < 3:
             return DP_WRITE_FAIL
         if dp_response[2] == 0:
             return DP_WRITE_OK
@@ -776,7 +799,9 @@ def sync_rtc():
     root.after(RTC_SYNC_FREQ_SECONDS*1000, sync_rtc)
     try:
         if THIS_DUCKYPAD.info_dict is not None:
-            duckypad_sync_rtc(myh)
+            # On Linux, use open-close mode to avoid keyboard issues
+            use_open_close = 'linux' in sys.platform
+            duckypad_sync_rtc(myh, use_open_close=use_open_close)
         return
     except Exception as e:
         print("sync_rtc:", e)

--- a/src/duckypad_autoprofile.py
+++ b/src/duckypad_autoprofile.py
@@ -195,19 +195,19 @@ def duckypad_connect():
     if dpp_is_fw_compatible(user_selected_dp) is False:
         return False
     
-    # Cache the HID path for open-close operations (helps with Linux keyboard issues)
-    from hid_common import set_cached_hid_path
+    from hid_common import set_cached_hid_path, _use_hidraw
     set_cached_hid_path(user_selected_dp['hid_path'])
     
-    if open_hid_path(user_selected_dp, myh) is False:
-        return False
-    
-    duckypad_sync_rtc(myh)
-    time.sleep(0.1)
-    
-    # Close the persistent HID connection on Linux to avoid keyboard input issues
-    if 'linux' in sys.platform:
-        myh.close()
+    if _use_hidraw:
+        # On Linux we use /dev/hidraw directly — no need for a persistent
+        # libusb connection that would detach the kernel HID driver.
+        duckypad_sync_rtc(myh, use_open_close=True)
+        time.sleep(0.1)
+    else:
+        if open_hid_path(user_selected_dp, myh) is False:
+            return False
+        duckypad_sync_rtc(myh)
+        time.sleep(0.1)
     
     THIS_DUCKYPAD.device_type = user_selected_dp['dp_model']
     THIS_DUCKYPAD.info_dict = user_selected_dp

--- a/src/hid_common.py
+++ b/src/hid_common.py
@@ -1,5 +1,6 @@
 import hid
 import sys
+import time
 from datetime import datetime
 import threading
 
@@ -29,6 +30,9 @@ def get_duckypad_path():
 
 PC_TO_DUCKYPAD_HID_BUF_SIZE = 64
 DUCKYPAD_TO_PC_HID_BUF_SIZE = 64
+# Report ID for custom HID interface - different on different platforms/devices
+CUSTOM_HID_REPORT_ID_WRITE = 5  # Report ID we use when writing
+CUSTOM_HID_REPORT_ID_READ = [4, 5]  # Report IDs we accept when reading (4 on some Linux setups)
 
 HID_RESPONSE_OK = 0
 HID_RESPONSE_ERROR = 1
@@ -51,12 +55,25 @@ def get_all_dp_info(dp_path_list):
     for this_path in dp_path_list:
         # print(this_path)
         myh = hid.device()
-        myh.open_path(this_path)
+        try:
+            myh.open_path(this_path)
+        except Exception:
+            continue
         myh.write(pc_to_duckypad_buf)
-        result = myh.read(DUCKYPAD_TO_PC_HID_BUF_SIZE)
+        # Filter for custom HID report (Report ID 4 or 5, varies by platform)
+        start_time = time.time()
+        result = None
+        while (time.time() - start_time) < 1.0:
+            remaining_ms = int((1.0 - (time.time() - start_time)) * 1000)
+            if remaining_ms <= 0:
+                break
+            buf = myh.read(DUCKYPAD_TO_PC_HID_BUF_SIZE, timeout_ms=min(remaining_ms, 100))
+            if buf and len(buf) > 0 and buf[0] in CUSTOM_HID_REPORT_ID_READ:
+                result = buf
+                break
         myh.close()
         # print(result)
-        if result[2] != HID_RESPONSE_OK:
+        if result is None or len(result) < 3 or result[2] != HID_RESPONSE_OK:
             continue
         this_dict = make_dp_info_dict(result, this_path)
         dp_info_list.append(this_dict)
@@ -74,15 +91,61 @@ def scan_duckypads():
 
 def get_empty_pc_to_duckypad_buf():
     ptd_buf = [0] * PC_TO_DUCKYPAD_HID_BUF_SIZE
-    ptd_buf[0] = 5   # HID Usage ID
+    ptd_buf[0] = CUSTOM_HID_REPORT_ID_WRITE   # HID Report ID for custom interface
     return ptd_buf
 
 def hid_txrx_nolock(buf_64b, hid_obj):
     print("\n\nSending to duckyPad:\n", buf_64b)
     hid_obj.write(buf_64b)
-    duckypad_to_pc_buf = hid_obj.read(DUCKYPAD_TO_PC_HID_BUF_SIZE, timeout_ms=500)
-    print("\nduckyPad response:\n", duckypad_to_pc_buf)
-    return duckypad_to_pc_buf
+    # Filter for custom HID report (Report ID 4 or 5, varies by platform)
+    start_time = time.time()
+    timeout_sec = 0.5
+    while (time.time() - start_time) < timeout_sec:
+        remaining_ms = int((timeout_sec - (time.time() - start_time)) * 1000)
+        if remaining_ms <= 0:
+            break
+        duckypad_to_pc_buf = hid_obj.read(DUCKYPAD_TO_PC_HID_BUF_SIZE, timeout_ms=min(remaining_ms, 50))
+        if duckypad_to_pc_buf and len(duckypad_to_pc_buf) > 0 and duckypad_to_pc_buf[0] in CUSTOM_HID_REPORT_ID_READ:
+            print("\nduckyPad response:\n", duckypad_to_pc_buf)
+            return duckypad_to_pc_buf
+    return None
+
+# Global storage for HID path - allows reopening device for each operation
+_cached_hid_path = None
+
+def set_cached_hid_path(path):
+    global _cached_hid_path
+    _cached_hid_path = path
+
+def get_cached_hid_path():
+    return _cached_hid_path
+
+def hid_txrx_open_close(buf_64b):
+    """Send command and receive response, opening device only for this operation.
+    This avoids keyboard input issues on Linux where keeping the HID device
+    open can interfere with the kernel HID driver."""
+    path = get_cached_hid_path()
+    if path is None:
+        return None
+    try:
+        temp_hid = hid.device()
+        temp_hid.open_path(path)
+    except Exception:
+        return None
+    try:
+        temp_hid.write(buf_64b)
+        start_time = time.time()
+        timeout_sec = 0.5
+        while (time.time() - start_time) < timeout_sec:
+            remaining_ms = int((timeout_sec - (time.time() - start_time)) * 1000)
+            if remaining_ms <= 0:
+                break
+            buf = temp_hid.read(DUCKYPAD_TO_PC_HID_BUF_SIZE, timeout_ms=min(remaining_ms, 50))
+            if buf and len(buf) > 0 and buf[0] in CUSTOM_HID_REPORT_ID_READ:
+                return buf
+        return None
+    finally:
+        temp_hid.close()
 
 def hid_txrx(buf_64b, hid_obj):
     if not hid_txrx_lock.acquire(timeout=2):
@@ -111,7 +174,7 @@ def i16_to_u8_list_be(value):
         (value >> 8) & 0xFF,
         value & 0xFF ]
 
-def duckypad_sync_rtc(hid_obj):
+def duckypad_sync_rtc(hid_obj, use_open_close=False):
     pc_to_duckypad_buf = get_empty_pc_to_duckypad_buf()
     unix_ts, utc_offset_minutes = get_timestamp_and_utc_offset()
     unix_ts_u8_list = u32_to_u8_list_be(unix_ts)
@@ -123,9 +186,10 @@ def duckypad_sync_rtc(hid_obj):
     pc_to_duckypad_buf[6] = unix_ts_u8_list[3]
     pc_to_duckypad_buf[7] = utc_offset_u8_list[0]
     pc_to_duckypad_buf[8] = utc_offset_u8_list[1]
-    print(pc_to_duckypad_buf)
-    result = hid_txrx(pc_to_duckypad_buf, hid_obj)
-    print("duckypad_sync_rtc:", result)
+    if use_open_close:
+        hid_txrx_open_close(pc_to_duckypad_buf)
+    else:
+        hid_txrx(pc_to_duckypad_buf, hid_obj)
 
 DP_MODEL_OG_DUCKYPAD = 20
 DP_MODEL_DUCKYPAD_PRO = 24

--- a/src/hid_common.py
+++ b/src/hid_common.py
@@ -1,6 +1,8 @@
 import hid
 import sys
 import time
+import os
+import select
 from datetime import datetime
 import threading
 
@@ -10,29 +12,106 @@ dp20_pid = 0xd11c
 dpp_pid = 0xd11d
 all_dp_pids = [dp20_pid, dpp_pid]
 
+DUCKYPAD_VID = 0x0483
+DUCKYPAD_VID_STR_UPPER = '00000483'
+DUCKYPAD_PID_STRS_UPPER = ['0000D11C', '0000D11D']
+
 def is_duckypad_pid(this_pid):
     return this_pid in all_dp_pids
 
+_use_hidraw = 'linux' in sys.platform
+
+# ---------------------------------------------------------------------------
+# Linux hidraw backend: communicates via /dev/hidraw* without detaching the
+# kernel HID driver. This is critical because duckyPad Pro exposes keyboard,
+# mouse, consumer-control AND custom-HID reports on a single USB interface.
+# The libusb backend calls libusb_claim_interface() which detaches the kernel
+# driver from the entire interface, blocking ALL keyboard/mouse input.
+# hidraw operates alongside the kernel driver — both receive HID reports.
+# ---------------------------------------------------------------------------
+
+def _linux_find_duckypad_hidraw_paths():
+    """Scan /sys/class/hidraw/ for duckyPad devices, return list of /dev/hidrawN paths."""
+    paths = []
+    hidraw_base = '/sys/class/hidraw'
+    if not os.path.isdir(hidraw_base):
+        return paths
+    for entry in os.listdir(hidraw_base):
+        uevent_path = os.path.join(hidraw_base, entry, 'device', 'uevent')
+        try:
+            with open(uevent_path) as f:
+                content = f.read()
+        except OSError:
+            continue
+        if DUCKYPAD_VID_STR_UPPER not in content:
+            continue
+        if not any(pid in content for pid in DUCKYPAD_PID_STRS_UPPER):
+            continue
+        paths.append(f'/dev/{entry}')
+    return paths
+
+def _linux_hidraw_txrx(path, buf_64b, timeout_sec=0.5):
+    """Send a 64-byte HID output report and read the response via hidraw.
+
+    Returns the response as a list of ints, or None on timeout/error.
+    The kernel driver stays attached — keyboard input is not disrupted.
+    """
+    fd = os.open(path, os.O_RDWR)
+    try:
+        os.write(fd, bytes(buf_64b))
+        deadline = time.monotonic() + timeout_sec
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            ready, _, _ = select.select([fd], [], [], min(remaining, 0.05))
+            if not ready:
+                continue
+            data = os.read(fd, 256)
+            if data and len(data) > 0 and data[0] in CUSTOM_HID_REPORT_ID_READ:
+                return list(data)
+    except OSError:
+        return None
+    finally:
+        os.close(fd)
+
+def _linux_get_all_dp_info(hidraw_paths):
+    """Get device info for all duckyPads found via hidraw."""
+    dp_info_list = []
+    pc_to_duckypad_buf = get_empty_pc_to_duckypad_buf()
+    for path in hidraw_paths:
+        result = _linux_hidraw_txrx(path, pc_to_duckypad_buf, timeout_sec=1.0)
+        if result is None or len(result) < 3 or result[2] != HID_RESPONSE_OK:
+            continue
+        this_dict = make_dp_info_dict(result, path)
+        dp_info_list.append(this_dict)
+    return dp_info_list
+
+# ---------------------------------------------------------------------------
+# Cross-platform public API
+# ---------------------------------------------------------------------------
+
 def get_duckypad_path():
+    if _use_hidraw:
+        return _linux_find_duckypad_hidraw_paths()
     dp_path_list = set()
     if 'win32' in sys.platform:
         for device_dict in hid.enumerate():
-            if device_dict['vendor_id'] == 0x0483 and \
+            if device_dict['vendor_id'] == DUCKYPAD_VID and \
             is_duckypad_pid(device_dict['product_id']) and \
             device_dict['usage'] == 58:
                 dp_path_list.add(device_dict['path'])
     else:
         for device_dict in hid.enumerate():
-            if device_dict['vendor_id'] == 0x0483 and \
+            if device_dict['vendor_id'] == DUCKYPAD_VID and \
             is_duckypad_pid(device_dict['product_id']):
                 dp_path_list.add(device_dict['path'])
     return list(dp_path_list)
 
 PC_TO_DUCKYPAD_HID_BUF_SIZE = 64
 DUCKYPAD_TO_PC_HID_BUF_SIZE = 64
-# Report ID for custom HID interface - different on different platforms/devices
-CUSTOM_HID_REPORT_ID_WRITE = 5  # Report ID we use when writing
-CUSTOM_HID_REPORT_ID_READ = [4, 5]  # Report IDs we accept when reading (4 on some Linux setups)
+CUSTOM_HID_REPORT_ID_WRITE = 5
+CUSTOM_HID_REPORT_ID_READ = [4, 5]
 
 HID_RESPONSE_OK = 0
 HID_RESPONSE_ERROR = 1
@@ -50,17 +129,17 @@ def make_dp_info_dict(hid_msg, hid_path):
     return this_dict
 
 def get_all_dp_info(dp_path_list):
+    if _use_hidraw:
+        return _linux_get_all_dp_info(dp_path_list)
     dp_info_list = []
     pc_to_duckypad_buf = get_empty_pc_to_duckypad_buf()
     for this_path in dp_path_list:
-        # print(this_path)
         myh = hid.device()
         try:
             myh.open_path(this_path)
         except Exception:
             continue
         myh.write(pc_to_duckypad_buf)
-        # Filter for custom HID report (Report ID 4 or 5, varies by platform)
         start_time = time.time()
         result = None
         while (time.time() - start_time) < 1.0:
@@ -72,7 +151,6 @@ def get_all_dp_info(dp_path_list):
                 result = buf
                 break
         myh.close()
-        # print(result)
         if result is None or len(result) < 3 or result[2] != HID_RESPONSE_OK:
             continue
         this_dict = make_dp_info_dict(result, this_path)
@@ -91,13 +169,12 @@ def scan_duckypads():
 
 def get_empty_pc_to_duckypad_buf():
     ptd_buf = [0] * PC_TO_DUCKYPAD_HID_BUF_SIZE
-    ptd_buf[0] = CUSTOM_HID_REPORT_ID_WRITE   # HID Report ID for custom interface
+    ptd_buf[0] = CUSTOM_HID_REPORT_ID_WRITE
     return ptd_buf
 
 def hid_txrx_nolock(buf_64b, hid_obj):
     print("\n\nSending to duckyPad:\n", buf_64b)
     hid_obj.write(buf_64b)
-    # Filter for custom HID report (Report ID 4 or 5, varies by platform)
     start_time = time.time()
     timeout_sec = 0.5
     while (time.time() - start_time) < timeout_sec:
@@ -110,7 +187,6 @@ def hid_txrx_nolock(buf_64b, hid_obj):
             return duckypad_to_pc_buf
     return None
 
-# Global storage for HID path - allows reopening device for each operation
 _cached_hid_path = None
 
 def set_cached_hid_path(path):
@@ -122,11 +198,16 @@ def get_cached_hid_path():
 
 def hid_txrx_open_close(buf_64b):
     """Send command and receive response, opening device only for this operation.
-    This avoids keyboard input issues on Linux where keeping the HID device
-    open can interfere with the kernel HID driver."""
+
+    On Linux, uses /dev/hidraw directly so the kernel HID driver stays attached
+    and keyboard/mouse input continues to work.
+    On other platforms, falls back to the hidapi library (libusb/IOKit).
+    """
     path = get_cached_hid_path()
     if path is None:
         return None
+    if _use_hidraw:
+        return _linux_hidraw_txrx(path, buf_64b)
     try:
         temp_hid = hid.device()
         temp_hid.open_path(path)
@@ -148,6 +229,8 @@ def hid_txrx_open_close(buf_64b):
         temp_hid.close()
 
 def hid_txrx(buf_64b, hid_obj):
+    if _use_hidraw:
+        return hid_txrx_open_close(buf_64b)
     if not hid_txrx_lock.acquire(timeout=2):
         return None
     try:


### PR DESCRIPTION
## Summary

Fixes a critical bug on Linux where the duckyPad stops working as a keyboard while the Autoswitcher application is running.

Closes #28

### Problem

On Linux, keeping the HID device open continuously interferes with the device's ability to send keyboard events to the system. The duckyPad buttons stop producing any input.

### Solution

Use an **open-close pattern** for HID communication on Linux:

```
open() → write() → read() → close()
```

This releases the device between operations, allowing it to function normally as a keyboard.

### Changes

#### `hid_common.py`
- Add `set_cached_hid_path()` to store the device path for reopening
- Add `hid_txrx_open_close()` function that opens, communicates, and closes
- Add Report ID filtering for custom HID interface (Report ID 4 or 5)
- Update `duckypad_sync_rtc()` to support open-close mode

#### `duckypad_autoprofile.py`
- Cache HID path during initial connection
- Close persistent connection on Linux after initial setup
- Use `hid_txrx_open_close()` for all HID operations on Linux
- Use open-close mode for RTC sync on Linux

### Platform Behavior

| Platform | Connection Mode |
|----------|-----------------|
| Linux    | Open-close (new) |
| Windows  | Persistent (unchanged) |
| macOS    | Persistent (unchanged) |

### Testing

Tested on:
- Arch Linux, Kernel 6.18.x, Wayland (Niri)
- duckyPad buttons work correctly while Autoswitcher is running